### PR TITLE
Add traces and metrics to OTLP observability stack

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -11,6 +11,14 @@ from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
 from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+from opentelemetry.instrumentation.flask import FlaskInstrumentor
+from opentelemetry import trace, metrics
 
 from app.healthcheck import blueprint as health_check_blueprint
 from app.songs import blueprint as songs_blueprint
@@ -22,22 +30,39 @@ LOG_FORMAT = ("%(levelname) -10s %(asctime)s %(name) "
 logging.basicConfig(level=os.environ.get(
     'LOG_LEVEL', 'INFO'), format=LOG_FORMAT)
 
+# Create shared resource for all telemetry
+resource = Resource.create({
+    "service.name": os.environ.get('OTEL_SERVICE_NAME', 'lastfm-last-played'),
+})
+
 # Set up OpenTelemetry logging with OTLP exporter
-logger_provider = LoggerProvider(
-    resource=Resource.create({
-        "service.name": os.environ.get('OTEL_SERVICE_NAME', 'lastfm-last-played'),
-    })
-)
+logger_provider = LoggerProvider(resource=resource)
 
 # Add OTLP exporter for logs
-otlp_exporter = OTLPLogExporter(
+otlp_log_exporter = OTLPLogExporter(
     endpoint=os.environ.get('OTEL_EXPORTER_OTLP_ENDPOINT', 'http://localhost:4318') + '/v1/logs',
 )
-logger_provider.add_log_record_processor(BatchLogRecordProcessor(otlp_exporter))
+logger_provider.add_log_record_processor(BatchLogRecordProcessor(otlp_log_exporter))
 
 # Attach OTLP handler to root logger to export all logs via OTLP
 handler = LoggingHandler(level=logging.NOTSET, logger_provider=logger_provider)
 logging.getLogger().addHandler(handler)
+
+# Set up OpenTelemetry tracing with OTLP exporter
+tracer_provider = TracerProvider(resource=resource)
+otlp_trace_exporter = OTLPSpanExporter(
+    endpoint=os.environ.get('OTEL_EXPORTER_OTLP_ENDPOINT', 'http://localhost:4318') + '/v1/traces',
+)
+tracer_provider.add_span_processor(BatchSpanProcessor(otlp_trace_exporter))
+trace.set_tracer_provider(tracer_provider)
+
+# Set up OpenTelemetry metrics with OTLP exporter
+otlp_metric_exporter = OTLPMetricExporter(
+    endpoint=os.environ.get('OTEL_EXPORTER_OTLP_ENDPOINT', 'http://localhost:4318') + '/v1/metrics',
+)
+metric_reader = PeriodicExportingMetricReader(otlp_metric_exporter)
+meter_provider = MeterProvider(resource=resource, metric_readers=[metric_reader])
+metrics.set_meter_provider(meter_provider)
 
 # pylint: disable=C0103
 app = Flask(__name__)
@@ -45,3 +70,6 @@ CORS(app)
 
 app.register_blueprint(health_check_blueprint.create_blueprint())
 app.register_blueprint(songs_blueprint.create_blueprint())
+
+# Instrument Flask app for automatic tracing and metrics
+FlaskInstrumentor().instrument_app(app)


### PR DESCRIPTION
## Summary
- Add TracerProvider with OTLPSpanExporter for distributed tracing
- Add MeterProvider with OTLPMetricExporter for metrics collection  
- Add FlaskInstrumentor for automatic Flask request tracing and metrics
- Refactor to use shared Resource across all telemetry providers (logs, traces, metrics)

## Problem
The service was only exporting **logs** to the OTEL collector. Even though the application code created traces using `tracer.start_as_current_span()` in `healthcheck.py` and `latest_songs.py`, these traces were never sent to the collector because no `TracerProvider` was configured.

## Solution
This PR completes the observability stack by adding:
1. **Traces** → Tempo (via OTEL collector)
2. **Metrics** → Prometheus (via OTEL collector)  
3. **Logs** → Loki (via OTEL collector) ✅ already working

## Test plan
- [ ] Deploy to Railway
- [ ] Verify traces appear in Tempo/Grafana
- [ ] Verify metrics appear in Prometheus
- [ ] Verify logs continue working in Loki
- [ ] Test a request to `/api/v1/latest_song` and confirm all 3 signals are captured

🤖 Generated with [Claude Code](https://claude.com/claude-code)